### PR TITLE
Use array for CORS allowed origins and change name of config key

### DIFF
--- a/src/main/kotlin/com/colivery/serviceaping/security/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/security/SecurityConfiguration.kt
@@ -21,8 +21,8 @@ import org.springframework.web.cors.CorsConfiguration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 class SecurityConfiguration(
-        @Value("\${colivery.frontend.url}")
-        private val frontendUrl: String
+        @Value("\${colivery.security.allowedOrigins}")
+        private val corsAllowedOrigins: Array<String>
 ) {
 
     @Bean
@@ -44,7 +44,7 @@ class SecurityConfiguration(
                     .and().csrf().disable()
                     .cors().configurationSource {
                         val corsConfig = CorsConfiguration()
-                        corsConfig.allowedOrigins = listOf(this.frontendUrl)
+                        corsConfig.allowedOrigins = this.corsAllowedOrigins.toList()
                         corsConfig.allowedHeaders = listOf("*")
                         corsConfig.allowedMethods = listOf("*")
 

--- a/src/main/resources/application-cloudsql.properties
+++ b/src/main/resources/application-cloudsql.properties
@@ -6,4 +6,3 @@ spring.cloud.gcp.sql.database-name           =${database_name}
 spring.datasource.continue-on-error          =true
 # Enforces database initialization
 spring.datasource.initialization-mode        =always
-colivery.frontend.url                        =https://colivery-app.web.app/

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,9 +6,10 @@ spring.cloud.gcp.firestore.enabled     =false
 firebase.database.url                  =https://colivery-app.firebaseio.com
 firebase.project.id                    =colivery-app
 firebase.credentials.path              =
-spring.profiles.active=${profiles_active}
-
+spring.profiles.active                 =${profiles_active}
 # Esri api configuration
-esri.find-addresses-url=https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates
-google.geocode-url=https://maps.googleapis.com/maps/api/geocode/json
-google.api-key=${google_maps_api_key}
+esri.find-addresses-url                =https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates
+google.geocode-url                     =https://maps.googleapis.com/maps/api/geocode/json
+google.api-key                         =${google_maps_api_key}
+# CORS Configuration - override this in your application-dev.properties for local development :-)
+colivery.security.allowedOrigins       =https://colivery-app.web.app/


### PR DESCRIPTION
Since we want to support multiple apps from different sources and URLs, we are now using an array for the `@Value` injection of the allowed origins. This enables the users to define a comma-separated list of URLs that should be allowed as CORS origins.  
The name of the config key was changed to better reflect what it really is for.