### PR TITLE
added changelog for admin user

### DIFF
--- a/src/main/resources/db/changelog/1.0.0/1592904580_add_admin_user.xml
+++ b/src/main/resources/db/changelog/1.0.0/1592904580_add_admin_user.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+    <changeSet author="ahodes" id="add_admin_user">
+        <sql>UPDATE public.user SET role = 'ADMIN' where email = 'hallo@machbarschaft.jetzt'</sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
added changelog for admin user that we have an initial admin user that we can use for creating help seekers and request