### PR TITLE
Add endpoint to search for help seekers

### DIFF
--- a/src/main/kotlin/com/colivery/serviceaping/persistence/repository/HelpSeekerRepository.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/persistence/repository/HelpSeekerRepository.kt
@@ -4,4 +4,6 @@ import com.colivery.serviceaping.persistence.entity.HelpSeekerEntity
 import org.springframework.data.repository.CrudRepository
 import java.util.*
 
-interface HelpSeekerRepository : CrudRepository<HelpSeekerEntity, UUID>
+interface HelpSeekerRepository : CrudRepository<HelpSeekerEntity, UUID> {
+    fun findByPhone(phone: String): HelpSeekerEntity?
+}

--- a/src/main/kotlin/com/colivery/serviceaping/rest/v1/services/HelpSeekerRestService.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/rest/v1/services/HelpSeekerRestService.kt
@@ -3,19 +3,18 @@ package com.colivery.serviceaping.rest.v1.services
 import com.colivery.serviceaping.extensions.getUser
 import com.colivery.serviceaping.mapping.toHelpSeekerEntity
 import com.colivery.serviceaping.mapping.toHelpSeekerResource
+import com.colivery.serviceaping.mapping.toUserResource
 import com.colivery.serviceaping.persistence.repository.HelpSeekerRepository
 import com.colivery.serviceaping.rest.v1.dto.`help-seeker`.CreateHelpSeekerDto
 import com.colivery.serviceaping.rest.v1.exception.BadRequestException
 import com.colivery.serviceaping.rest.v1.resources.HelpSeekerResource
 import org.springframework.http.MediaType
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.validation.BeanPropertyBindingResult
 import org.springframework.validation.Errors
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import reactor.core.publisher.Mono
 
 @RestController
@@ -40,5 +39,11 @@ class HelpSeekerRestService(
         return Mono.just(resource)
     }
 
+    @GetMapping("/search/{phoneNumber}")
+    @PreAuthorize("hasRole('ROLE_HOTLINE')")
+    fun searchHelpSeekerByPhone(@PathVariable phoneNumber: String) =
+            Mono.justOrEmpty(this.helpSeekerRepository.findByPhone(phoneNumber)?.let {
+                toHelpSeekerResource(it)
+            })
 
 }


### PR DESCRIPTION
The new endpoint allows the hotline bot to search for help seekers by phone number to retrieve the ID for later use when creating a new help request for them