### PR TITLE
feat: drop not null constraint on location

### DIFF
--- a/src/main/resources/db/changelog/1.0.0/1605685124_drop_constraints_location.xml
+++ b/src/main/resources/db/changelog/1.0.0/1605685124_drop_constraints_location.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet author="wirths" id="drop_constraints_location">
+        <dropNotNullConstraint columnName="zip_code"
+                               tableName="user"/>
+        <dropNotNullConstraint columnName="city"
+                               tableName="user"/>
+        <dropNotNullConstraint columnName="location"
+                               tableName="user"/>
+        <dropNotNullConstraint columnName="location_geo_hash"
+                               tableName="user"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This change might be reverted in the future but serves the web app integration currently. We are not requesting address data thus we cannot set the previously required database columns.