### PR TITLE
added changelog for altering request status enum

### DIFF
--- a/src/main/resources/db/changelog/1.0.0/1632510987_update_help_request_type.xml
+++ b/src/main/resources/db/changelog/1.0.0/1632510987_update_help_request_type.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+<changeSet author="ahodes" id="update_help_request_type" context="baseline">
+    <sql dbms="postgresql">
+        ALTER TABLE help_request ALTER COLUMN status TYPE VARCHAR(255);
+        ALTER TABLE help_request ALTER COLUMN status DROP DEFAULT;
+        DROP TYPE IF EXISTS request_status;
+        CREATE TYPE request_status AS ENUM ('OPEN', 'WIP', 'CLOSED', 'DELETED');
+        ALTER TABLE help_request ALTER COLUMN status TYPE request_status USING (status::request_status);
+        ALTER TABLE help_request ALTER COLUMN status SET DEFAULT 'OPEN';
+    </sql>
+</changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
added changelog script for altering the request status. It needs several steps:

1. Alter column for table to varchar instead of enum
2. Create enum from new by adding the new value
3. Alter the column back to enum

see: https://stackoverflow.com/questions/53149484/error-alter-type-add-cannot-run-inside-a-transaction-block