### PR TITLE
Give help requests their own location

### DIFF
--- a/src/main/kotlin/com/colivery/serviceaping/mapping/HelpRequestMapping.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/mapping/HelpRequestMapping.kt
@@ -1,17 +1,22 @@
 package com.colivery.serviceaping.mapping
 
+import com.colivery.serviceaping.extensions.toGeoPoint
+import com.colivery.serviceaping.extensions.toGeoPointResource
 import com.colivery.serviceaping.persistence.entity.HelpRequestEntity
 import com.colivery.serviceaping.persistence.entity.HelpSeekerEntity
 import com.colivery.serviceaping.persistence.entity.UserEntity
 import com.colivery.serviceaping.rest.v1.dto.`help-request`.CreateHelpRequestDto
 import com.colivery.serviceaping.rest.v1.resources.HelpRequestResource
+import org.locationtech.jts.geom.GeometryFactory
 
-fun toHelpRequestEntity(helpRequest: CreateHelpRequestDto, adminUser: UserEntity, helpSeeker: HelpSeekerEntity) =
+fun toHelpRequestEntity(helpRequest: CreateHelpRequestDto, adminUser: UserEntity, helpSeeker:
+HelpSeekerEntity, geometryFactory: GeometryFactory) =
         HelpRequestEntity(
                 requestText = helpRequest.requestText,
                 requestStatus = helpRequest.requestStatus,
                 adminUser = adminUser,
-                helpSeeker = helpSeeker
+                helpSeeker = helpSeeker,
+                location = helpRequest.location?.toGeoPoint(geometryFactory)
         )
 
 fun toHelpRequestResource(helpRequest: HelpRequestEntity) =
@@ -23,5 +28,8 @@ fun toHelpRequestResource(helpRequest: HelpRequestEntity) =
                 requestText =  helpRequest.requestText,
                 adminUser =  toUserResource(helpRequest.adminUser),
                 helpSeeker =  toHelpSeekerResource(helpRequest.helpSeeker),
-                helper = toUserResourceNullable(helpRequest.helper)
+                helper = toUserResourceNullable(helpRequest.helper),
+                location = (helpRequest.location
+                        ?: helpRequest.helpSeeker.user?.location
+                        ?: helpRequest.helpSeeker.enteredBy.location)?.toGeoPointResource()
         )

--- a/src/main/kotlin/com/colivery/serviceaping/persistence/entity/HelpRequestEntity.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/persistence/entity/HelpRequestEntity.kt
@@ -2,6 +2,7 @@ package com.colivery.serviceaping.persistence.entity
 
 import com.colivery.serviceaping.persistence.RequestStatus
 import org.hibernate.annotations.Type
+import org.locationtech.jts.geom.Point
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -31,7 +32,10 @@ data class HelpRequestEntity(
 
         @ManyToOne(optional = true, fetch = FetchType.EAGER)
         @JoinColumn(name = "helper_id")
-        var helper: UserEntity? = null
+        var helper: UserEntity? = null,
+
+        @Column(nullable = true)
+        var location: Point? = null
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)

--- a/src/main/kotlin/com/colivery/serviceaping/rest/v1/dto/help-request/CreateHelpRequestDto.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/rest/v1/dto/help-request/CreateHelpRequestDto.kt
@@ -1,6 +1,7 @@
 package com.colivery.serviceaping.rest.v1.dto.`help-request`
 
 import com.colivery.serviceaping.persistence.RequestStatus
+import com.colivery.serviceaping.rest.v1.resources.GeoPointResource
 import org.springframework.validation.annotation.Validated
 import javax.validation.constraints.NotNull
 
@@ -13,5 +14,7 @@ class CreateHelpRequestDto (
     val requestStatus: RequestStatus,
 
     @field:NotNull
-    val helpSeeker: String
+    val helpSeeker: String,
+
+    val location: GeoPointResource?
 )

--- a/src/main/kotlin/com/colivery/serviceaping/rest/v1/resources/HelpRequestResource.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/rest/v1/resources/HelpRequestResource.kt
@@ -12,5 +12,6 @@ class HelpRequestResource (
     val requestText: String,
     val adminUser: UserResource,
     val helpSeeker: HelpSeekerResource,
-    val helper: UserResource?
+    val helper: UserResource?,
+    val location: GeoPointResource?
 )

--- a/src/main/kotlin/com/colivery/serviceaping/rest/v1/services/HelpRequestRestService.kt
+++ b/src/main/kotlin/com/colivery/serviceaping/rest/v1/services/HelpRequestRestService.kt
@@ -11,6 +11,7 @@ import com.colivery.serviceaping.rest.v1.dto.`help-request`.HelpRequestStatusDto
 import com.colivery.serviceaping.rest.v1.dto.`help-request`.UpdateHelpRequestContentDto
 import com.colivery.serviceaping.rest.v1.exception.BadRequestException
 import com.colivery.serviceaping.rest.v1.resources.HelpRequestResource
+import org.locationtech.jts.geom.GeometryFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -28,9 +29,10 @@ import java.util.*
 @Validated
 @RequestMapping("/v1/help-request", produces = [MediaType.APPLICATION_JSON_VALUE])
 class HelpRequestRestService(
-        private val helpRequestRepository: HelpRequestRepository,
-        private val helpSeekerRepository: HelpSeekerRepository,
-        private val userRepository: UserRepository
+    private val helpRequestRepository: HelpRequestRepository,
+    private val helpSeekerRepository: HelpSeekerRepository,
+    private val userRepository: UserRepository,
+    private val geometryFactory: GeometryFactory
 ) {
     @PostMapping
     fun createHelpRequest(@RequestBody helpRequest: CreateHelpRequestDto, authentication: Authentication):
@@ -54,7 +56,8 @@ class HelpRequestRestService(
         }
 
         val adminUser = authentication.getUser()
-        val entity = toHelpRequestEntity(helpRequest, adminUser, helpSeeker.get())
+        val entity = toHelpRequestEntity(helpRequest, adminUser, helpSeeker.get(),
+            this.geometryFactory)
         val helpRequestEntity = this.helpRequestRepository.save(entity)
         val resource = toHelpRequestResource(helpRequestEntity)
 

--- a/src/main/resources/db/changelog/1.0.0/1632062305_add_location_to_help_request.xml
+++ b/src/main/resources/db/changelog/1.0.0/1632062305_add_location_to_help_request.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+<changeSet id="1632062305_add_location_to_help_request" author="nschoellhorn">
+    <addColumn tableName="help_request">
+        <column name="location" type="geometry(Point, 4326)">
+            <constraints nullable="true"/>
+        </column>
+    </addColumn>
+</changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Help Requests now can get their own location during creation. If it's omitted, it falls back to the "enteredBy" user's location.